### PR TITLE
safari-style-tweak

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@
 
 * {
   box-sizing: border-box;
+  -webkit-appearance: none;
 }
 
 body {


### PR DESCRIPTION
Inserted `-webkit-appearance: none;` into the CSS so that the button styles will look as they are intended to on mobile Safari.