### PR TITLE
safari-style-tweak

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,6 @@
 
 * {
   box-sizing: border-box;
-  -webkit-appearance: none;
 }
 
 body {
@@ -52,9 +51,11 @@ h1 span {
 .submit-btn {
   background-color: #00A79D;
   border: none;
+  border-radius: none;
   color: #FFFFFF;
   font-size: 1.6vw;
   padding: 0rem;
+  -webkit-appearance: none;
 }
 
 .submit-btn:hover {


### PR DESCRIPTION
Placed `-webkit-appearance: none;` directly in the button element, and added `border-radius: none;` in the hopes of gaining control of our button style on iOS Safari.